### PR TITLE
Ajouter un module DNS pour gérer la zone sur Scaleway

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,28 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/integrations/github" {
-  version = "6.6.0"
-  hashes = [
-    "h1:Fp0RrNe+w167AQkVUWC1WRAsyjhhHN7aHWUky7VkKW8=",
-    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
-    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
-    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
-    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
-    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
-    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
-    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
-    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
-    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
-    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
-    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
-    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
-    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
-    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
-    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
-  ]
-}
-
 provider "registry.terraform.io/scaleway/scaleway" {
   version = "2.52.0"
   hashes = [

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source = "scaleway/scaleway"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+resource "scaleway_domain_zone" "zone" {
+  domain    = "inclusion.gouv.fr"
+  subdomain = ""
+}
+
+resource "scaleway_domain_record" "main" {
+  for_each = var.records
+
+  dns_zone = scaleway_domain_zone.zone.domain
+  name     = each.value.name
+  data     = each.value.data
+  type     = each.value.type
+  ttl      = each.value.ttl
+  priority = each.value.priority
+}

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -1,0 +1,20 @@
+variable "managed" {
+  type        = string
+  description = "Indicates the resource is managed by Terraform"
+}
+
+variable "organization_id" {
+  type        = string
+  description = "ID of the Scaleway org"
+}
+
+variable "records" {
+  type = map(object({
+    name     = string
+    data     = string
+    type     = string
+    ttl      = optional(number, 3600)
+    priority = optional(number, 0)
+  }))
+  description = "DNS records in the zone. The id must be unique."
+}

--- a/email.tf
+++ b/email.tf
@@ -1,0 +1,84 @@
+module "dns-mail" {
+  source = "./dns"
+
+  providers = { scaleway = scaleway.terraform_ci }
+
+  organization_id = var.scw_organization_id
+  managed         = local.managed
+  records = {
+    # Umbrella Brevo organization, root of all Brevo sub-projects.
+    "brevo-code-2d8d" = {
+      name = ""
+      data = "brevo-code:2d8d9f5f1d2fb27858f79eacaf64817d"
+      type = "TXT"
+    },
+    "dmarc" = {
+      name = "_dmarc"
+      data = "v=DMARC1; p=quarantine; rua=mailto:98224b9a@in.mailhardener.com,mailto:dmarc@inclusion.gouv.fr,mailto:rua@dmarc.brevo.com!10m; fo=1"
+      type = "TXT"
+    },
+    "google-dkim" = {
+      name = "google._domainkey"
+      data = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtYhB99qk0vLYpSd+nHCkR0TLE1K2v2OdQQb6NUso2aAhUiimuOOQ06EDapnhK4IGSEXISTW3fTXBECEGmeyQ6mZKsElS24k/O+0Q33ANvBCJf+4bkm7A7/ITj2rsbRZYRJXpjdrfD/wvc+FUf6h9gIE9/h1PNeA0vaTSBJnsqNX7bszw9W+8WMzf/vLm6Wii+76GhCZvVtN8s/4EZz5hW+TcbsHAouTcOuuUxx+wfkgEkkycBHuYjw9vszyNt/PBMxmKQXnrx8QxODZ03sc/CnQBDwc/JT7heWiFqbVSdN8VE0y42CFFuDa+JBNXFGv/qzLfePISppswEwn9AixlPwIDAQAB"
+      type = "TXT"
+      ttl  = 300
+    },
+    "google-mx-alt1" = {
+      name     = ""
+      data     = "alt1.aspmx.l.google.com."
+      type     = "MX"
+      priority = 5
+    },
+    "google-mx-alt2" = {
+      name     = ""
+      data     = "alt2.aspmx.l.google.com."
+      type     = "MX"
+      priority = 5
+    },
+    "google-mx-alt3" = {
+      name     = ""
+      data     = "alt3.aspmx.l.google.com."
+      type     = "MX"
+      priority = 10
+    },
+    "google-mx-alt4" = {
+      name     = ""
+      data     = "alt4.aspmx.l.google.com."
+      type     = "MX"
+      priority = 10
+    },
+    "google-mx-main" = {
+      name     = ""
+      data     = "aspmx.l.google.com."
+      type     = "MX"
+      priority = 1
+    },
+    "mail-dkim" = {
+      name = "mail._domainkey"
+      data = "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDeMVIzrCa3T14JsNY0IRv5/2V1/v2itlviLQBwXsa7shBD6TrBkswsFUToPyMRWC9tbR/5ey0nRBH0ZVxp+lsmTxid2Y2z+FApQ6ra2VsXfbJP3HE6wAO0YTVEJt1TmeczhEd2Jiz/fcabIISgXEdSpTYJhb0ct0VJRxcg4c8c7wIDAQAB"
+      type = "TXT"
+      ttl  = 10800
+    },
+    "mta-sts-site" = {
+      name = "mta-sts"
+      data = "inclusion.gouv.fr."
+      type = "CNAME"
+    },
+    "mta-sts-txt" = {
+      name = "_mta-sts"
+      data = "v=STSv1; id=20250314T120200"
+      type = "TXT"
+      ttl  = 10800
+    },
+    "smtp.tls" = {
+      name = "_smtp._tls"
+      data = "v=TLSRPTv1; rua=mailto:98224b9a@in.mailhardener.com"
+      type = "TXT"
+    },
+    "spf" = {
+      name = ""
+      data = "v=spf1 include:bnc3.mailjet.com include:spf.brevo.com include:_spf.google.com include:mail.zendesk.com ~all"
+      type = "TXT"
+    },
+  }
+}

--- a/emplois.tf
+++ b/emplois.tf
@@ -1,0 +1,20 @@
+module "dns-emplois" {
+  source = "./dns"
+
+  providers = { scaleway = scaleway.terraform_ci }
+
+  organization_id = var.scw_organization_id
+  managed         = local.managed
+  records = {
+    "emplois-brevo-code" : {
+      name = "emplois"
+      data = "brevo-code:7a18495fb1b2ffa39ca7ad0c1e70adcb"
+      type = "TXT"
+    },
+    "emplois-website" = {
+      name = "emplois"
+      data = "domain.par.clever-cloud.com."
+      type = "ALIAS"
+    },
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,86 @@ module "bootstrap" {
   managed = local.managed
 }
 
+module "dns-root" {
+  source = "./dns"
+
+  providers = { scaleway = scaleway.terraform_ci }
+
+  organization_id = var.scw_organization_id
+  managed         = local.managed
+  records = {
+    "ciso" = {
+      name = "ciso"
+      data = "51.15.213.160"
+      type = "A"
+    },
+    "cle-nir" = {
+      name = "cle-nir"
+      data = "calculette-nir-production.osc-fr1.scalingo.io."
+      type = "CNAME"
+    },
+    "etudes" = {
+      name = "etudes"
+      data = "cname.tally.so."
+      type = "CNAME"
+      ttl  = 10800
+    },
+    "google-site-verification-YGht5" = {
+      name = ""
+      data = "google-site-verification=YGht5JTr0ujMA6cSZrZ9ysejKIn4ESV0v_ZQHL0hPqE"
+      type = "TXT"
+    },
+    "google-workspace-key" = {
+      name = "tpqsxaxytsb6"
+      data = "gv-wnkxgmqxqqr3tm.dv.googlehosted.com."
+      type = "CNAME"
+      ttl  = 10800
+    }
+    "notion-dcv.pages" = {
+      name = "_notion-dcv.pages"
+      data = "1295f321-b604-81f8-8544-007038d42424"
+      type = "TXT"
+    },
+    "ns0" = {
+      name = ""
+      data = "ns0.dom.scw.cloud."
+      type = "NS"
+      ttl  = 1800
+    },
+    "ns1" = {
+      name = ""
+      data = "ns1.dom.scw.cloud."
+      type = "NS"
+      ttl  = 1800
+    },
+    "pages" = {
+      name = "pages"
+      data = "external.notion.site."
+      type = "CNAME"
+    },
+    "website1" = {
+      name = ""
+      data = "185.21.194.105"
+      type = "A"
+    },
+    "website2" = {
+      name = ""
+      data = "80.247.12.255"
+      type = "A"
+    },
+    "website3" = {
+      name = ""
+      data = "80.247.13.145"
+      type = "A"
+    },
+    "website4" = {
+      name = ""
+      data = "148.253.96.193"
+      type = "A"
+    },
+  }
+}
+
 output "ci_access_key" {
   value     = module.bootstrap.ci_access_key
   sensitive = true

--- a/marche.tf
+++ b/marche.tf
@@ -1,0 +1,15 @@
+module "dns-marche" {
+  source = "./dns"
+
+  providers = { scaleway = scaleway.terraform_ci }
+
+  organization_id = var.scw_organization_id
+  managed         = local.managed
+  records = {
+    "brevo-code-marche" = {
+      name = ""
+      data = "brevo-code:96720ae72c4b9e35f0b138dac0f441c4"
+      type = "TXT"
+    },
+  }
+}


### PR DESCRIPTION
Je n’ai pas importé les enregistrements de type NS associés aux enregistrements A, AAA, CNAME, parce que Scaleway les crée automatiquement. Je suppose que c’est pour remplacer les DNS de Gandi. :shrug: 

Pour la petite histoire, j’ai utilisé la CLI Scaleway pour importer tous les enregistrements sur ma machine, puis j’ai fait un petit massage aux données avec mon éditeur favori pour les organiser proprement. Ensuite, j’ai galéré à essayer de faire `terraform import` dans un module qui lit une map (vraiment pas très convaincu de l’utilité du module), pour finalement `terraform plan` puis `terraform apply`, en espérant qu’il ne crée par tous les enregistrements en double. Succès.
```bash
$ scw dns record list inclusion.gouv.fr --output json >records.json
```
