### PR TITLE
Revert "Use an ALIAS for the website inclusion.gouv.fr"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,10 +64,25 @@ module "dns-root" {
       data = "external.notion.site."
       type = "CNAME"
     },
-    "website" = {
+    "website1" = {
       name = ""
-      data = "gip-inclusion-website-production.osc-secnum-fr1.scalingo.io."
-      type = "ALIAS"
+      data = "185.21.194.105"
+      type = "A"
+    },
+    "website2" = {
+      name = ""
+      data = "80.247.12.255"
+      type = "A"
+    },
+    "website3" = {
+      name = ""
+      data = "80.247.13.145"
+      type = "A"
+    },
+    "website4" = {
+      name = ""
+      data = "148.253.96.193"
+      type = "A"
     },
   }
 }


### PR DESCRIPTION
Revert du commit f08e1dd50fa0e67e46e55f8f37da078a43cc3bd5.

À cause des travaux pour la CNAV, l’état actuel des ressources est différent du state déclaré dans ce repository et le `terraform apply` échoue. Pour éviter d’avoir des changements non appliqués sur `main`, mieux vaut _revert_ ce changement.
