### PR TITLE
Mise à jour de la policy IAM pour l'application terraform-ci

### DIFF
--- a/infrastructure/iac-gip-inclusion/iam/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/iam/terraform/main.tf
@@ -28,9 +28,8 @@ resource "scaleway_iam_policy" "terraform_ci" {
   rule {
     organization_id = data.scaleway_account_project.default.organization_id
     permission_set_names = [
-      "IAMReadOnly",
-      # Verify the terraform project existence.
-      "ProjectReadOnly",
+      "IAMManager",
+      "ProjectManager",
     ]
   }
   rule {


### PR DESCRIPTION
Permet de gérer :
- Ressources IAM (utilisateurs, groupes, applications, policies)
- Projets (mais pas leurs propres ressources qui sont gérées séparément)

Permissions déjà attribuées via la console (car la PR s'octroie les permissions requises pour appliquer la PR), en somme ça supprime juste le drift.