### PR TITLE
ops(dns): add a CNAME record for lemarche.inclusion.gouv.fr

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/marche/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/marche/terraform/main.tf
@@ -20,5 +20,10 @@ module "dns-marche" {
       data = "brevo-code:96720ae72c4b9e35f0b138dac0f441c4"
       type = "TXT"
     },
+    "website" = {
+      name = "lemarche"
+      data = "domain.par.clever-cloud.com."
+      type = "CNAME"
+    }
   }
 }


### PR DESCRIPTION
Utilisation d'un `CNAME` plutôt qu'un `ALIAS` sur demande de Sébastien