### PR TITLE
feat: add 5 new dora subdomains

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
@@ -27,5 +27,29 @@ module "dns-dora" {
       type = "NS"
       ttl  = 1800
     },
+    "prod-website" = {
+      name = "dora"
+      data = "dora-front-prod.osc-secnum-fr1.scalingo.io."
+      type = "ALIAS"
+      ttl = 300
+    },
+    "staging-website" = {
+      name = "staging.dora"
+      data = "dora-front-staging.osc-secnum-fr1.scalingo.io."
+      type = "CNAME"
+      ttl = 300
+    },
+    "prod-api" = {
+      name = "api.dora"
+      data = "dora-back-prod.osc-secnum-fr1.scalingo.io."
+      type = "CNAME"
+      ttl = 300
+    },
+    "staging-api" = {
+      name = "api.staging.dora"
+      data = "dora-back-staging.osc-secnum-fr1.scalingo.io."
+      type = "CNAME"
+      ttl = 300
+    },
   }
 }

--- a/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
@@ -51,5 +51,11 @@ module "dns-dora" {
       type = "CNAME"
       ttl = 300
     },
+    "metabase" = {
+      name = "metabase.dora"
+      data = "dora-metabase-v2.osc-secnum-fr1.scalingo.io."
+      type = "CNAME"
+      ttl = 300
+    },
   }
 }


### PR DESCRIPTION
In order to migrate Dora to the `inclusion.gouv.fr`, this PR creates five new subdomains. One for staging and one for prod for both the website and the api as well as one for metabase.

Since `prod-website` uses the apex subdomain `dora.inclusion.gouv.fr`, I used `ALIAS` as the type while I used `CNAME` for the other three since they are deeper subdomains. I also set the ttl to 300 to allow for quicker rollout and to provide more flexibility in the event of a rollback.