### PR TITLE
Suppression de la délégation de zone de DORA

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
@@ -15,47 +15,35 @@ module "dns-dora" {
   scw_zone   = var.scw_zone
 
   records = {
-    "ns0" = {
-      name = "dora"
-      data = "ns0.dom.scw.cloud."
-      type = "NS"
-      ttl  = 1800
-    },
-    "ns1" = {
-      name = "dora"
-      data = "ns1.dom.scw.cloud."
-      type = "NS"
-      ttl  = 1800
-    },
     "prod-website" = {
       name = "dora"
       data = "dora-front-prod.osc-secnum-fr1.scalingo.io."
       type = "ALIAS"
-      ttl = 300
+      ttl  = 300
     },
     "staging-website" = {
       name = "staging.dora"
       data = "dora-front-staging.osc-secnum-fr1.scalingo.io."
       type = "CNAME"
-      ttl = 300
+      ttl  = 300
     },
     "prod-api" = {
       name = "api.dora"
       data = "dora-back-prod.osc-secnum-fr1.scalingo.io."
       type = "CNAME"
-      ttl = 300
+      ttl  = 300
     },
     "staging-api" = {
       name = "api.staging.dora"
       data = "dora-back-staging.osc-secnum-fr1.scalingo.io."
       type = "CNAME"
-      ttl = 300
+      ttl  = 300
     },
     "metabase" = {
       name = "metabase.dora"
       data = "dora-metabase-v2.osc-secnum-fr1.scalingo.io."
       type = "CNAME"
-      ttl = 300
+      ttl  = 300
     },
   }
 }


### PR DESCRIPTION
Précédemment DORA avait sa propre zone DNS, administrée manuellement sur son propre projet Scaleway.

Tout étant à présent géré par l'IaC, suppression de la délégation.