### PR TITLE
DNS: Add bitwarden.inclusion.gouv.fr

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -15,6 +15,11 @@ module "dns-gip-inclusion" {
   scw_zone   = var.scw_zone
 
   records = {
+    "bitwarden" = {
+      name = "bitwarden"
+      data = "bitwarden.inclusion.cloud-ed.fr."
+      type = "CNAME"
+    },
     "ciso" = {
       name = "ciso"
       data = "51.15.213.160"


### PR DESCRIPTION
Avoid reliance on the deprecated domain gip-inclusion.org.