### PR TITLE
Fix du step find_run

### DIFF
--- a/.github/workflows/_terraform-module.yml
+++ b/.github/workflows/_terraform-module.yml
@@ -206,7 +206,7 @@ jobs:
         run: |
           set -euo pipefail
           run_id="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/terraform-orchestrator.yml/runs" \
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/terraform-orchestrator.yml/runs" \
               -f event=pull_request \
               -f head_sha='${{ steps.find_pr.outputs.plan-sha }}' \
               -F per_page=1 \


### PR DESCRIPTION
Forçage de la méthode HTTP en `GET`

Avec `gh api`, `GET` est la méthode par défaut sauf si `-f/-F` sont passées, auquel cas le défaut passe en `POST`

Refs: https://cli.github.com/manual/gh_api