### PR TITLE
feat: add @dora.inclusion.gouv.fr email domain

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/dora/terraform/main.tf
@@ -45,5 +45,10 @@ module "dns-dora" {
       type = "CNAME"
       ttl  = 300
     },
+    "brevo-code" = {
+      name= "dora"
+      data = "brevo-code:0b4f86ed9b3dd6d700ad7212f801c544"
+      type= "TXT"
+    },
   }
 }


### PR DESCRIPTION
In order to migrate our email domain to `@dora.inclusion.gouv.fr`, this PR includes the brevo code in order to authenticate this email domain