### PR TITLE
docs: Clarifier quelle langue doit être utilisée dans le projet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ module-name/
 
 ### Conventions de Nommage
 
+Le code source, y compris les commentaires, et les messages de commits doivent être en anglais.
+La documentation ainsi que les titres et les descriptions des pull requests doivent être en français.
+Ces deux derniers éléments font partie des livrables pour le détenteur du marché public et pourront faire l’objet d’un audit par la cour des comptes. 
+
 #### Ressources Terraform
 
 ```hcl


### PR DESCRIPTION
Vu que les titres et les descriptions des PRs doivent être en français et le code et les commentaires doivent être en anglais, ce PR ajoute une clarification a `Contributing.MD` pour éviter la confusion.