### PR TITLE
Gérer un message de dépréciation dans les providers du module dns

### DIFF
--- a/infrastructure/_modules/dns/records/terraform/providers.tf
+++ b/infrastructure/_modules/dns/records/terraform/providers.tf
@@ -1,8 +1,4 @@
 provider "scaleway" {
-  alias = "tmp"
-}
-
-provider "scaleway" {
   region     = var.scw_region
   zone       = var.scw_zone
   project_id = var.scw_project_id

--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/README.md
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/README.md
@@ -35,3 +35,4 @@
 
 No outputs.
 <!-- END_TF_DOCS -->
+Foo bar

--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = ">= 1.10"
 }
 
+# Foo bar
 module "dns-gip-inclusion" {
   source = "../../../../_modules/dns/records/terraform"
 


### PR DESCRIPTION
```
Warning: Redundant empty provider block

  on ../../../../_modules/dns/records/terraform/providers.tf line 1:
   1: provider "scaleway" {

Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That
approach was ambiguous and is now deprecated.

If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "scaleway" blocks and then adding or updating an entry like the following to the
required_providers block of module.dns-gip-inclusion:
    scaleway = {
      source = "hashicorp/scaleway"
      configuration_aliases = [
        scaleway.tmp,
      ]
    }
```
