### PR TITLE
Sous-domaine explorations-nova

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -37,6 +37,12 @@ module "dns-gip-inclusion" {
       type = "CNAME"
       ttl  = 10800
     },
+    "explorations-nova" = {
+      name = "explorations-nova"
+      data = "novarw2u9ckv-explorations.functions.fnc.fr-par.scw.cloud."
+      type = "CNAME"
+      ttl  = 10800
+    },
     "formulaires" = {
       name = "formulaires"
       data = "fagerh.osc-fr1.scalingo.io."


### PR DESCRIPTION
Domaine qui pointe vers un conteneur Scaleway équipé d’oauth-proxy, pour de la diffusion et de l’outillage interne.