### PR TITLE
Domaines pour application Autometa et tableaux de bord publics

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -16,6 +16,12 @@ module "dns-gip-inclusion" {
   scw_project_id = data.scaleway_account_project.iac_gip_inclusion.project_id
 
   records = {
+    "autometa" = {
+      name = "autometa"
+      data = "matometa.osc-fr1.scalingo.io."
+      type = "CNAME"
+      ttl  = 10800
+    },
     "bitwarden" = {
       name = "bitwarden"
       data = "bitwarden.inclusion.cloud-ed.fr."
@@ -92,6 +98,18 @@ module "dns-gip-inclusion" {
       name = "pages"
       data = "external.notion.site."
       type = "CNAME"
+    },
+    "staging-statistiques" = {
+      name = "staging.statistiques"
+      data = "tableaux-de-bord-staging.s3.fr-par.scw.cloud."
+      type = "CNAME"
+      ttl  = 10800
+    },
+    "statistiques" = {
+      name = "statistiques"
+      data = "tableaux-de-bord-publics.s3.fr-par.scw.cloud."
+      type = "CNAME"
+      ttl  = 10800
     },
     "traiteurs-engages" = {
       name = "traiteurs.engages"


### PR DESCRIPTION
# Pourquoi ?

Autometa et ses dashboards deviennent des outils du quotidien.

- La publication de tableaux de bord générés par Autometa va nécessiter une URL. Un domaine de staging est ajouté pour permettre les itérations.
- Un nom fixe est donné à Autometa en anticipation de futurs changements d'infrastructure.

# Quoi ?

`https://statistiques.inclusion.gouv.fr` et `https://staging.statistiques.inclusion.gouv.fr` pointent chacun vers un bucket S3 chez Scaleway. 
`http://autometa.inclusion.gouv.fr/` pointe vers l'application Scalingo.