### PR TITLE
Update CNAME record for traiteurs-engages

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -113,7 +113,7 @@ module "dns-gip-inclusion" {
     },
     "traiteurs-engages" = {
       name = "traiteurs.engages"
-      data = "traiteurs-engages-tmp.osc-fr1.scalingo.io."
+      data = "proxy.applicatif.net."
       type = "CNAME"
     },
     "website" = {


### PR DESCRIPTION
## :thinking: Pourquoi ?
Mise à jour de l'enregistrement CNAME pour le sous-domaine `traiteurs.engages.inclusion.gouv.fr` 
afin de pointer vers la nouvelle infrastructure de la plateforme Les Traiteurs Engagés
développée par une agence no-code partenaire (AuCarré via Ksaar)

## :cake: Comment ?
Remplacement de la cible temporaire `traiteurs-engages-tmp.osc-fr1.scalingo.io.` 
par `proxy.applicatif.net.` fournie par l'agence en charge du développement de la plateforme.

## 📜 Instructions de Ksaar

Pour configurer la redirection de votre domaine vers votre application, voici les étapes à suivre :
• Configurer votre DNS
Vous devez ajouter un enregistrement CNAME pointant vers : https://proxy.applicatif.net/
(Pré-requis : avoir accès à la gestion DNS de votre domaine)
• Nous envoyer un lien vers l’application côté Maker
:warning: Si vous utilisez un SSO, pensez à mettre à jour les URLs de redirection avec ce nouveau domaine.

