### PR TITLE
Ajout de l'enregistrement connect.inclusion.gouv.fr

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -26,6 +26,11 @@ module "dns-gip-inclusion" {
       data = "51.15.213.160"
       type = "A"
     },
+    "connect" = {
+      name = "connect"
+      data = "app-67c39aa7-af32-4740-a673-81152b5453e7.cleverapps.io."
+      type = "CNAME"
+    },
     "cle-nir" = {
       name = "cle-nir"
       data = "calculette-nir-production.osc-fr1.scalingo.io."


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un domaine pour inclusion connect


## :cake: Comment ? <!-- optionnel -->

Un CNAME qui pointe vers la ressource Clever


## :rotating_light: À vérifier

- [x] Le commit message est rédigé en anglais
- [x] Le titre de la PR et sa présente description sont en français
