### PR TITLE
Ajout de l'entrée DNS staging.traiteurs-engages.inclusion.gouv.fr

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -116,7 +116,12 @@ module "dns-gip-inclusion" {
       type = "CNAME"
       ttl  = 10800
     },
-    "traiteurs-engages" = {
+    "traiteurs-engages-staging" = {
+      name = "staging.traiteurs-engages"
+      data = "traiteurs-engages-staging.osc-fr1.scalingo.io."
+      type = "CNAME"
+    },
+    "traiteurs-engages-prod" = {
       name = "traiteurs.engages"
       data = "proxy.applicatif.net."
       type = "CNAME"
@@ -127,4 +132,9 @@ module "dns-gip-inclusion" {
       type = "ALIAS"
     },
   }
+}
+
+moved {
+  from = module.dns-gip-inclusion.scaleway_domain_record.records["traiteurs-engages"]
+  to   = module.dns-gip-inclusion.scaleway_domain_record.records["traiteurs-engages-prod"]
 }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour avoir un CNAME qui pointe sur l'env de staging sur scalingo.


## :cake: Comment ? <!-- optionnel -->

Ajout du CNAME.
Renommage de l'ancienne entrée dans le state concernant la prod.