### PR TITLE
Suppression des références à traiteurs-engages de gip-inclusion/dns

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -116,25 +116,10 @@ module "dns-gip-inclusion" {
       type = "CNAME"
       ttl  = 10800
     },
-    "traiteurs-engages-staging" = {
-      name = "staging.traiteurs-engages"
-      data = "traiteurs-engages-staging.osc-fr1.scalingo.io."
-      type = "CNAME"
-    },
-    "traiteurs-engages-prod" = {
-      name = "traiteurs.engages"
-      data = "proxy.applicatif.net."
-      type = "CNAME"
-    },
     "website" = {
       name = ""
       data = "site-institutionnel-2025-proxy.osc-fr1.scalingo.io."
       type = "ALIAS"
     },
   }
-}
-
-moved {
-  from = module.dns-gip-inclusion.scaleway_domain_record.records["traiteurs-engages"]
-  to   = module.dns-gip-inclusion.scaleway_domain_record.records["traiteurs-engages-prod"]
 }

--- a/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
@@ -28,13 +28,3 @@ module "dns-traiteurs-engages" {
     },
   }
 }
-
-import {
-  to = module.dns-traiteurs-engages.scaleway_domain_record.records["staging"]
-  id = "inclusion.gouv.fr/e0d64f79-928e-4c44-9758-5211f9bb8cd6"
-}
-
-import {
-  to = module.dns-traiteurs-engages.scaleway_domain_record.records["prod"]
-  id = "inclusion.gouv.fr/ea9b0c4a-6f6a-4658-9326-5d3a3fb6d8f9"
-}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Refs: #132
Du nettoyage


## :rotating_light: À vérifier

- [x] Clean le state manuellement pour ne pas causer de suppression
