### PR TITLE
Ajout d'un compteur d'imports dans le résumé du plan Terraform en CI

### DIFF
--- a/.github/workflows/_terraform-module.yml
+++ b/.github/workflows/_terraform-module.yml
@@ -133,6 +133,7 @@ jobs:
           set -euo pipefail
 
           # Count actions from human output
+          imports=$(grep -c "will be imported" "$PLAN_DIR/tfplan.txt" || true)
           creates=$(grep -c "will be created" "$PLAN_DIR/tfplan.txt" || true)
           updates=$(grep -c "will be updated in-place" "$PLAN_DIR/tfplan.txt" || true)
           replaces=$(grep -c "must be replaced" "$PLAN_DIR/tfplan.txt" || true)
@@ -141,9 +142,9 @@ jobs:
           {
             echo "### Résumé du plan pour \`${MODULE_LABEL}\`"
             echo
-            echo "| Créations | Mises à jour | Remplacements | Destructions |"
-            echo "|----------:|-------------:|--------------:|-------------:|"
-            echo "| $creates  | $updates     | $replaces     | $destroys    |"
+            echo "| Imports  | Créations | Mises à jour | Remplacements | Destructions |"
+            echo "|---------:|----------:|-------------:|--------------:|-------------:|"
+            echo "| $imports | $creates  | $updates     | $replaces     | $destroys    |"
             echo
             echo "<details><summary>Voir le plan complet</summary>"
             echo


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que c'était invisibilisé, exemple : https://github.com/gip-inclusion/infrastructure/actions/runs/25327948172#summary-74253639075 (déployer le plan complet)

## :cake: Comment ? <!-- optionnel -->

En rajoutant une colonne "Imports" avant les créations pour respecter l'ordre terraform (ex: `Plan: 2 to import, 0 to add, 0 to change, 0 to destroy.`)