### PR TITLE
Mise à jour des enregistrements web de traiteurs-engages : CNAME à ALIAS

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
@@ -19,12 +19,12 @@ module "dns-traiteurs-engages" {
     "staging" = {
       name = "staging.traiteurs-engages"
       data = "traiteurs-engages-staging.osc-fr1.scalingo.io."
-      type = "CNAME"
+      type = "ALIAS"
     },
     "prod" = {
       name = "traiteurs.engages"
       data = "proxy.applicatif.net."
-      type = "CNAME"
+      type = "ALIAS"
     },
 
     # Emails


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les TXT ne sont pas supportés pour un même FQDN avec CNAME.

Refs: https://www.ietf.org/rfc/rfc1912.txt - 2.4 CNAME records

> A CNAME record is not allowed to coexist with any other data.


## :cake: Comment ? <!-- optionnel -->

En passant le type à ALIAS.