### PR TITLE
Installation d'AGE à partir des dépôts Ubuntu

### DIFF
--- a/.github/workflows/_terraform-module.yml
+++ b/.github/workflows/_terraform-module.yml
@@ -63,23 +63,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "::group::Install AGE (latest)"
-
-          # Fetch the last version using the /releases/latest redirection
-          version="$(curl -fsSLI -o /dev/null -w '%{url_effective}' -L https://github.com/FiloSottile/age/releases/latest \
-                     | sed --regexp-extended 's#.*/tag/v([^/]+)$#\1#')"
-          echo "Latest age version: $version"
-
-          url="https://github.com/FiloSottile/age/releases/download/v${version}/age-v${version}-linux-amd64.tar.gz"
-          tmp="$(mktemp -d)"
-          curl -fsSL "$url" | tar -xz -C "$tmp"
-
-          sudo install -m 0755 "$tmp/age/age"        /usr/local/bin/age
-          sudo install -m 0755 "$tmp/age/age-keygen" /usr/local/bin/age-keygen
-
-          # Check installation is OK
-          /usr/local/bin/age --version || true
-          echo "::endgroup::"
+          sudo apt-get update
+          sudo apt-get install -y age
+          age --version
 
       - name: Populating env vars
         shell: bash


### PR DESCRIPTION
## :thinking: Pourquoi ?

Par sécurité.

Refs https://github.com/gip-inclusion/infrastructure/pull/136#discussion_r3190470535

---

Validé ici : https://github.com/gip-inclusion/infrastructure/actions/runs/25672603673/job/75361669107#step:5:1