### PR TITLE
Ajout du projet Scaleway et du bucket S3 pour traiteurs-engages

### DIFF
--- a/infrastructure/organization/projects/terraform/README.md
+++ b/infrastructure/organization/projects/terraform/README.md
@@ -26,6 +26,7 @@ No modules.
 | [scaleway_account_project.iac_gip_inclusion](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/account_project) | resource |
 | [scaleway_account_project.site_institutionnel_2025](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/account_project) | resource |
 | [scaleway_account_project.terraform](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/account_project) | resource |
+| [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/account_project) | resource |
 
 ## Inputs
 

--- a/infrastructure/organization/projects/terraform/main.tf
+++ b/infrastructure/organization/projects/terraform/main.tf
@@ -31,3 +31,8 @@ resource "scaleway_account_project" "site_institutionnel_2025" {
   name        = "site-institutionnel-2025"
   description = var.managed
 }
+
+resource "scaleway_account_project" "traiteurs_engages" {
+  name        = "traiteurs-engages"
+  description = var.managed
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/.terraform.lock.hcl
+++ b/infrastructure/traiteurs-engages/buckets/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.74.0"
+  constraints = ">= 2.55.0"
+  hashes = [
+    "h1:5n+g2HCkYkTgDHqFG7W41thlxdPuL6SFPXg8yAHoMO8=",
+    "h1:jNEA55OShsH+Ynn03n7Vcd9JfggOVJfCY47NEnTTDB4=",
+    "h1:rNTjcv2RS7rhZO+JIC43Y3ARWhTC2Jf549xVc3mBELQ=",
+    "zh:02142c6d0d5b1a71498fea9de9d1d0fcd4b2fc107eec5d0aafde916cf660762c",
+    "zh:19e6f1e01b52532781f1dc68629dc8147a1949a55ac62595d8cda4dd5021bd63",
+    "zh:2f3fb601af0a6a772c508bb3d685581d4e2cbfed2889e4630ff5ff99c5a74030",
+    "zh:389c21278804381701ad1b08b1c3fb9515aed86f19114f4b8bbf1c19011cd05d",
+    "zh:51aa0d98dbcc5b9b101043662703130205f383e356116dd0b471c62e89cdc6f2",
+    "zh:60377f27c2dcf66f6148c3c350829554914493f71ae35a178b26b28606b1107d",
+    "zh:71599a9b19fe30791127d3e970ab71243f08108075cea87a0a7e60af771c84f6",
+    "zh:abaac0ba730b2a3cafa948fa94557bb081422ddbdea8193582766ebd229e3be7",
+    "zh:b688d66cf335625e7bbd3505be7dd902bcb99ca1c105da8aa5591b76de1584a8",
+    "zh:c1275c4770f112c4bd513cdd55f90f3d26e794394f4ede5fd2b62e0c10feb64a",
+    "zh:cfa1bd45e2f06fe57641432af2574e1192a67c4f98f5bc2d615ef0f9b8a53a73",
+    "zh:d5d3b8c297633515baa8e443e1bb3636dd1c87bd1780b69d4fd7bed6e533b390",
+    "zh:d781196ec91c43bfbda84a0f69d5eda40410ba8f8feb2e9691a9784f606fe98f",
+  ]
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/README.md
+++ b/infrastructure/traiteurs-engages/buckets/terraform/README.md
@@ -1,0 +1,68 @@
+# Traiteurs engagés - Bucket pour les fichiers uploadés
+
+Ce module Terraform crée et configure un bucket Object Storage Scaleway
+(API S3) pour stocker les fichiers manipulés par l'application
+Traiteurs engagés : logos et photos des traiteurs, pièces jointes des
+demandes, factures et devis PDF générés, etc.
+
+## Caractéristiques
+
+- **Versioning** activé sur le bucket, pour pouvoir récupérer un objet
+  écrasé ou supprimé par mégarde.
+- **ACL `private`** : aucun accès public par défaut. Les objets ne
+  sortent du bucket que via une URL signée ou via l'application
+  authentifiée.
+- **Politique IAM ciblée** : deux _statements_ uniquement —
+  l'application `traiteurs-engages` (déclarée dans le module IAM voisin)
+  peut lire/écrire/supprimer des objets, le `terraform-ci` peut
+  administrer la configuration du bucket. Aucun autre principal n'a
+  accès.
+
+## Ordre d'apply
+
+Ce module dépend du module `../iam/` (la data source
+`scaleway_iam_application.traiteurs_engages` doit pouvoir résoudre).
+Apply d'abord `iam/`, puis `buckets/`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.55.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.74.0 |
+| <a name="provider_scaleway.tmp"></a> [scaleway.tmp](#provider\_scaleway.tmp) | 2.74.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [scaleway_object_bucket.uploads_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
+| [scaleway_object_bucket_acl.uploads_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_policy.uploads_bucket_policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_policy) | resource |
+| [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
+| [scaleway_iam_application.terraform_ci](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
+| [scaleway_iam_application.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_managed"></a> [managed](#input\_managed) | Indicates the resource is managed by Terraform | `string` | `"Managed by Terraform"` | no |
+| <a name="input_scw_region"></a> [scw\_region](#input\_scw\_region) | Scaleway region for resources | `string` | n/a | yes |
+| <a name="input_scw_zone"></a> [scw\_zone](#input\_scw\_zone) | Scaleway zone for resources | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/infrastructure/traiteurs-engages/buckets/terraform/backend.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket                      = "gip-inclusion-state"
+    key                         = "traiteurs-engages/buckets/terraform/terraform.tfstate"
+    region                      = "fr-par"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/data.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/data.tf
@@ -1,0 +1,12 @@
+data "scaleway_account_project" "traiteurs_engages" {
+  name     = "traiteurs-engages"
+  provider = scaleway.tmp
+}
+
+data "scaleway_iam_application" "traiteurs_engages" {
+  name = "traiteurs-engages"
+}
+
+data "scaleway_iam_application" "terraform_ci" {
+  name = "terraform-ci"
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = ">= 2.55.0"
+    }
+  }
+  required_version = ">= 1.10"
+}
+
+resource "scaleway_object_bucket" "uploads_bucket" {
+  provider = scaleway
+  name     = "traiteurs-engages-uploads"
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "uploads_bucket_acl" {
+  bucket = scaleway_object_bucket.uploads_bucket.id
+  acl    = "private"
+}
+
+resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
+  depends_on = [scaleway_object_bucket_acl.uploads_bucket_acl]
+  bucket     = scaleway_object_bucket.uploads_bucket.id
+  policy = jsonencode(
+    {
+      Version = "2023-04-17",
+      Statement = [
+        {
+          Sid    = "Allow Terraform CI to manage the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.terraform_ci.id}",
+            ],
+          },
+          Action = [
+            "s3:GetBucketAcl",
+            "s3:GetBucketCORS",
+            "s3:GetBucketLocation",
+            "s3:GetBucketObjectLockConfiguration",
+            "s3:GetBucketTagging",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketWebsite",
+            "s3:GetLifecycleConfiguration",
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:PutBucketAcl",
+            "s3:PutBucketCORS",
+            "s3:PutBucketObjectLockConfiguration",
+            "s3:PutBucketTagging",
+            "s3:PutBucketVersioning",
+            "s3:PutBucketWebsite",
+            "s3:PutLifecycleConfiguration",
+          ],
+          Resource = [
+            scaleway_object_bucket.uploads_bucket.name,
+          ],
+        },
+        {
+          Sid    = "Allow the traiteurs-engages app to store and retrieve objects in the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages.id}",
+            ],
+          },
+          Action = [
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket.name}/*",
+          ],
+        },
+      ],
+    },
+  )
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/provider.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/provider.tf
@@ -1,0 +1,9 @@
+provider "scaleway" {
+  alias = "tmp"
+}
+
+provider "scaleway" {
+  region     = var.scw_region
+  zone       = var.scw_zone
+  project_id = data.scaleway_account_project.traiteurs_engages.id
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/terraform.tfvars
+++ b/infrastructure/traiteurs-engages/buckets/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+scw_region = "fr-par"
+scw_zone   = "fr-par-1"

--- a/infrastructure/traiteurs-engages/buckets/terraform/variables.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/variables.tf
@@ -1,0 +1,15 @@
+variable "managed" {
+  type        = string
+  description = "Indicates the resource is managed by Terraform"
+  default     = "Managed by Terraform"
+}
+
+variable "scw_region" {
+  type        = string
+  description = "Scaleway region for resources"
+}
+
+variable "scw_zone" {
+  type        = string
+  description = "Scaleway zone for resources"
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/.terraform.lock.hcl
+++ b/infrastructure/traiteurs-engages/iam/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.74.0"
+  constraints = ">= 2.55.0"
+  hashes = [
+    "h1:5n+g2HCkYkTgDHqFG7W41thlxdPuL6SFPXg8yAHoMO8=",
+    "h1:jNEA55OShsH+Ynn03n7Vcd9JfggOVJfCY47NEnTTDB4=",
+    "h1:rNTjcv2RS7rhZO+JIC43Y3ARWhTC2Jf549xVc3mBELQ=",
+    "zh:02142c6d0d5b1a71498fea9de9d1d0fcd4b2fc107eec5d0aafde916cf660762c",
+    "zh:19e6f1e01b52532781f1dc68629dc8147a1949a55ac62595d8cda4dd5021bd63",
+    "zh:2f3fb601af0a6a772c508bb3d685581d4e2cbfed2889e4630ff5ff99c5a74030",
+    "zh:389c21278804381701ad1b08b1c3fb9515aed86f19114f4b8bbf1c19011cd05d",
+    "zh:51aa0d98dbcc5b9b101043662703130205f383e356116dd0b471c62e89cdc6f2",
+    "zh:60377f27c2dcf66f6148c3c350829554914493f71ae35a178b26b28606b1107d",
+    "zh:71599a9b19fe30791127d3e970ab71243f08108075cea87a0a7e60af771c84f6",
+    "zh:abaac0ba730b2a3cafa948fa94557bb081422ddbdea8193582766ebd229e3be7",
+    "zh:b688d66cf335625e7bbd3505be7dd902bcb99ca1c105da8aa5591b76de1584a8",
+    "zh:c1275c4770f112c4bd513cdd55f90f3d26e794394f4ede5fd2b62e0c10feb64a",
+    "zh:cfa1bd45e2f06fe57641432af2574e1192a67c4f98f5bc2d615ef0f9b8a53a73",
+    "zh:d5d3b8c297633515baa8e443e1bb3636dd1c87bd1780b69d4fd7bed6e533b390",
+    "zh:d781196ec91c43bfbda84a0f69d5eda40410ba8f8feb2e9691a9784f606fe98f",
+  ]
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/README.md
+++ b/infrastructure/traiteurs-engages/iam/terraform/README.md
@@ -1,0 +1,60 @@
+# Traiteurs engagés - Configuration IAM
+
+Ce module Terraform crée et configure les ressources IAM nécessaires pour
+que l'application Traiteurs engagés puisse se connecter au bucket Object
+Storage du projet.
+
+Il déclare :
+
+- une **application IAM** dédiée à l'application (servant d'identité
+  technique),
+- une **clé d'API** liée à cette application — c'est cette clé que
+  l'application consomme pour signer ses requêtes S3,
+- une **politique IAM** restreinte au projet `traiteurs-engages`, qui
+  autorise uniquement les opérations Object Storage nécessaires
+  (lecture/écriture/suppression d'objets, lecture du bucket).
+
+La clé d'API est sensible : elle ne doit jamais être committée. Elle se
+récupère dans la console Scaleway (ou via `terraform output` si un
+output est ajouté ultérieurement) puis se passe à l'application sous
+forme de variables d'environnement.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.55.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.74.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [scaleway_iam_api_key.api_key](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_api_key) | resource |
+| [scaleway_iam_application.app](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
+| [scaleway_iam_policy.policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_policy) | resource |
+| [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_managed"></a> [managed](#input\_managed) | Indicates the resource is managed by Terraform | `string` | `"Managed by Terraform"` | no |
+| <a name="input_scw_region"></a> [scw\_region](#input\_scw\_region) | Scaleway region for resources | `string` | n/a | yes |
+| <a name="input_scw_zone"></a> [scw\_zone](#input\_scw\_zone) | Scaleway zone for resources | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/infrastructure/traiteurs-engages/iam/terraform/backend.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket                      = "gip-inclusion-state"
+    key                         = "traiteurs-engages/iam/terraform/terraform.tfstate"
+    region                      = "fr-par"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/data.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/data.tf
@@ -1,0 +1,3 @@
+data "scaleway_account_project" "traiteurs_engages" {
+  name = "traiteurs-engages"
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = ">= 2.55.0"
+    }
+  }
+  required_version = ">= 1.10"
+}
+
+resource "scaleway_iam_application" "app" {
+  name        = "traiteurs-engages"
+  description = var.managed
+}
+
+resource "scaleway_iam_api_key" "api_key" {
+  application_id = scaleway_iam_application.app.id
+  description    = var.managed
+  # When authenticating Object Storage operations, SCW uses the default project
+  # linked to the API key.
+  default_project_id = data.scaleway_account_project.traiteurs_engages.project_id
+}
+
+resource "scaleway_iam_policy" "policy" {
+  name           = "traiteurs-engages"
+  description    = var.managed
+  application_id = scaleway_iam_application.app.id
+  rule {
+    project_ids = [data.scaleway_account_project.traiteurs_engages.project_id]
+    permission_set_names = [
+      "ObjectStorageBucketsRead",
+      "ObjectStorageObjectsDelete",
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+    ]
+  }
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/provider.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider "scaleway" {
+  region = var.scw_region
+  zone   = var.scw_zone
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/terraform.tfvars
+++ b/infrastructure/traiteurs-engages/iam/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+scw_region = "fr-par"
+scw_zone   = "fr-par-1"

--- a/infrastructure/traiteurs-engages/iam/terraform/variables.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/variables.tf
@@ -1,0 +1,15 @@
+variable "scw_region" {
+  type        = string
+  description = "Scaleway region for resources"
+}
+
+variable "scw_zone" {
+  type        = string
+  description = "Scaleway zone for resources"
+}
+
+variable "managed" {
+  type        = string
+  description = "Indicates the resource is managed by Terraform"
+  default     = "Managed by Terraform"
+}


### PR DESCRIPTION
## Contexte

L'application `traiteurs-engages` stocke aujourd'hui les fichiers uploadés par les utilisateurs (logos et photos de traiteurs, PDFs de devis générés) sur le filesystem local de son conteneur Scalingo — ils disparaissent à chaque redeploy. Cette PR pose l'infrastructure d'un Object Storage externe Scaleway pour les y déplacer.

## Contenu

Reprend exactement le layout `site-institutionnel-2025/` (un projet Scaleway par produit, sous-modules `buckets/` et `iam/`) :

- **`organization/projects/`** — Déclaration de `scaleway_account_project.traiteurs_engages` pour que toutes les ressources vivent dans leur projet dédié (conformément à la politique du repo : pas de ressources dans le projet par défaut).
- **`traiteurs-engages/iam/`** — Application IAM + clé d'API + politique IAM scopée sur le nouveau projet. La politique accorde uniquement `ObjectStorageBucketsRead`, `ObjectStorageObjectsRead/Write/Delete` — c'est cette identité que l'app utilisera pour signer ses requêtes S3.
- **`traiteurs-engages/buckets/`** — Bucket `traiteurs-engages-uploads` privé, versioning activé, ACL `private`. La policy bucket autorise l'app IAM à lire/écrire/supprimer des objets, et `terraform-ci` à administrer la configuration du bucket. Aucun autre principal n'a accès.

## Ordre d'apply

1. `organization/projects/` (crée le projet Scaleway)
2. `traiteurs-engages/iam/` (crée l'app IAM nommée `traiteurs-engages` que la policy bucket data-sourcera)
3. `traiteurs-engages/buckets/` (crée le bucket + sa policy)

Les trois s'orchestrent automatiquement via le workflow `terraform-orchestrator` quand cette PR sera mergée sur `main`.

## Suivi côté app

Une fois la clé d'API IAM récupérée dans la console Scaleway, elle devra être passée à l'app `traiteurs-engages` sous forme de variables d'environnement (`SCW_ACCESS_KEY`, `SCW_SECRET_KEY` ou équivalent `AWS_*` côté SDK S3) — fait dans un PR séparé côté repo applicatif.

## Vérifications locales

- `terraform fmt -recursive -check` : passe (image hashicorp/terraform:1.10)
- `terraform validate` sur les 3 modules (organization/projects, iam, buckets) : passe en mode `-backend=false`
- `terraform-docs` (v0.20.0) injecté dans les 3 READMEs ; le diff CI ne devrait rien trouver à régénérer
- Lockfiles `.terraform.lock.hcl` générés en multi-plateformes (`darwin_amd64`, `linux_amd64`, `darwin_arm64`) comme dans `site-institutionnel-2025`