### PR TITLE
Autorisation donnée à terraform-ci sur le projet traiteurs-engages

### DIFF
--- a/infrastructure/iac-gip-inclusion/iam/terraform/README.md
+++ b/infrastructure/iac-gip-inclusion/iam/terraform/README.md
@@ -29,6 +29,7 @@ No modules.
 | [scaleway_account_project.iac_gip_inclusion](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
 | [scaleway_account_project.site_institutionnel_2025](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
 | [scaleway_account_project.terraform](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
+| [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
 
 ## Inputs
 

--- a/infrastructure/iac-gip-inclusion/iam/terraform/data.tf
+++ b/infrastructure/iac-gip-inclusion/iam/terraform/data.tf
@@ -13,3 +13,7 @@ data "scaleway_account_project" "emplois_cnav" {
 data "scaleway_account_project" "site_institutionnel_2025" {
   name = "site-institutionnel-2025"
 }
+
+data "scaleway_account_project" "traiteurs_engages" {
+  name = "traiteurs-engages"
+}

--- a/infrastructure/iac-gip-inclusion/iam/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/iam/terraform/main.tf
@@ -43,7 +43,8 @@ resource "scaleway_iam_policy" "terraform_ci" {
     project_ids = [
       data.scaleway_account_project.iac_gip_inclusion.project_id,
       data.scaleway_account_project.emplois_cnav.project_id,
-      data.scaleway_account_project.site_institutionnel_2025.project_id
+      data.scaleway_account_project.site_institutionnel_2025.project_id,
+      data.scaleway_account_project.traiteurs_engages.project_id
     ]
     permission_set_names = [
       "AllProductsFullAccess",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que la CI puisse effectuer des opérations sur ce projet.