### PR TITLE
Ajout du bucket pour les uploads du site traiteurs-engages

### DIFF
--- a/infrastructure/traiteurs-engages/buckets/terraform/.terraform.lock.hcl
+++ b/infrastructure/traiteurs-engages/buckets/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.74.0"
+  constraints = ">= 2.55.0"
+  hashes = [
+    "h1:5n+g2HCkYkTgDHqFG7W41thlxdPuL6SFPXg8yAHoMO8=",
+    "h1:jNEA55OShsH+Ynn03n7Vcd9JfggOVJfCY47NEnTTDB4=",
+    "h1:rNTjcv2RS7rhZO+JIC43Y3ARWhTC2Jf549xVc3mBELQ=",
+    "zh:02142c6d0d5b1a71498fea9de9d1d0fcd4b2fc107eec5d0aafde916cf660762c",
+    "zh:19e6f1e01b52532781f1dc68629dc8147a1949a55ac62595d8cda4dd5021bd63",
+    "zh:2f3fb601af0a6a772c508bb3d685581d4e2cbfed2889e4630ff5ff99c5a74030",
+    "zh:389c21278804381701ad1b08b1c3fb9515aed86f19114f4b8bbf1c19011cd05d",
+    "zh:51aa0d98dbcc5b9b101043662703130205f383e356116dd0b471c62e89cdc6f2",
+    "zh:60377f27c2dcf66f6148c3c350829554914493f71ae35a178b26b28606b1107d",
+    "zh:71599a9b19fe30791127d3e970ab71243f08108075cea87a0a7e60af771c84f6",
+    "zh:abaac0ba730b2a3cafa948fa94557bb081422ddbdea8193582766ebd229e3be7",
+    "zh:b688d66cf335625e7bbd3505be7dd902bcb99ca1c105da8aa5591b76de1584a8",
+    "zh:c1275c4770f112c4bd513cdd55f90f3d26e794394f4ede5fd2b62e0c10feb64a",
+    "zh:cfa1bd45e2f06fe57641432af2574e1192a67c4f98f5bc2d615ef0f9b8a53a73",
+    "zh:d5d3b8c297633515baa8e443e1bb3636dd1c87bd1780b69d4fd7bed6e533b390",
+    "zh:d781196ec91c43bfbda84a0f69d5eda40410ba8f8feb2e9691a9784f606fe98f",
+  ]
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/README.md
+++ b/infrastructure/traiteurs-engages/buckets/terraform/README.md
@@ -1,0 +1,47 @@
+# Traiteurs engagés - Bucket pour les fichiers uploadés
+
+Ce module Terraform crée et configure un bucket S3 pour stocker les fichiers manipulés par l'application
+Traiteurs engagés : logos et photos des traiteurs, pièces jointes des demandes, factures et devis PDF générés, etc.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.55.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.74.0 |
+| <a name="provider_scaleway.tmp"></a> [scaleway.tmp](#provider\_scaleway.tmp) | 2.74.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [scaleway_object_bucket.uploads_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
+| [scaleway_object_bucket_acl.uploads_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_policy.uploads_bucket_policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_policy) | resource |
+| [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
+| [scaleway_iam_application.terraform_ci](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
+| [scaleway_iam_application.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_managed"></a> [managed](#input\_managed) | Indicates the resource is managed by Terraform | `string` | `"Managed by Terraform"` | no |
+| <a name="input_scw_region"></a> [scw\_region](#input\_scw\_region) | Scaleway region for resources | `string` | n/a | yes |
+| <a name="input_scw_zone"></a> [scw\_zone](#input\_scw\_zone) | Scaleway zone for resources | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/infrastructure/traiteurs-engages/buckets/terraform/backend.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket                      = "gip-inclusion-state"
+    key                         = "traiteurs-engages/buckets/terraform/terraform.tfstate"
+    region                      = "fr-par"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/data.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/data.tf
@@ -1,0 +1,12 @@
+data "scaleway_account_project" "traiteurs_engages" {
+  name     = "traiteurs-engages"
+  provider = scaleway.tmp
+}
+
+data "scaleway_iam_application" "traiteurs_engages" {
+  name = "traiteurs-engages"
+}
+
+data "scaleway_iam_application" "terraform_ci" {
+  name = "terraform-ci"
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = ">= 2.55.0"
+    }
+  }
+  required_version = ">= 1.10"
+}
+
+resource "scaleway_object_bucket" "uploads_bucket" {
+  provider = scaleway
+  name     = "traiteurs-engages-uploads"
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "uploads_bucket_acl" {
+  bucket = scaleway_object_bucket.uploads_bucket.id
+  acl    = "private"
+}
+
+resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
+  depends_on = [scaleway_object_bucket_acl.uploads_bucket_acl]
+  bucket     = scaleway_object_bucket.uploads_bucket.id
+  policy = jsonencode(
+    {
+      Version = "2023-04-17",
+      Statement = [
+        {
+          Sid    = "Allow Terraform CI to manage the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.terraform_ci.id}",
+            ],
+          },
+          Action = [
+            "s3:GetBucketAcl",
+            "s3:GetBucketCORS",
+            "s3:GetBucketLocation",
+            "s3:GetBucketObjectLockConfiguration",
+            "s3:GetBucketTagging",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketWebsite",
+            "s3:GetLifecycleConfiguration",
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:PutBucketAcl",
+            "s3:PutBucketCORS",
+            "s3:PutBucketObjectLockConfiguration",
+            "s3:PutBucketTagging",
+            "s3:PutBucketVersioning",
+            "s3:PutBucketWebsite",
+            "s3:PutLifecycleConfiguration",
+          ],
+          Resource = [
+            scaleway_object_bucket.uploads_bucket.name,
+          ],
+        },
+        {
+          Sid    = "Allow the traiteurs-engages app to store and retrieve objects in the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages.id}",
+            ],
+          },
+          Action = [
+            # Bucket permissions
+            "s3:ListBucket",
+
+            # Object permissions
+            "s3:AbortMultipartUpload",
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket.name}",
+            "${scaleway_object_bucket.uploads_bucket.name}/*",
+          ],
+        },
+      ],
+    },
+  )
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/provider.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/provider.tf
@@ -1,0 +1,9 @@
+provider "scaleway" {
+  alias = "tmp"
+}
+
+provider "scaleway" {
+  region     = var.scw_region
+  zone       = var.scw_zone
+  project_id = data.scaleway_account_project.traiteurs_engages.id
+}

--- a/infrastructure/traiteurs-engages/buckets/terraform/terraform.tfvars
+++ b/infrastructure/traiteurs-engages/buckets/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+scw_region = "fr-par"
+scw_zone   = "fr-par-1"

--- a/infrastructure/traiteurs-engages/buckets/terraform/variables.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/variables.tf
@@ -1,0 +1,15 @@
+variable "scw_region" {
+  type        = string
+  description = "Scaleway region for resources"
+}
+
+variable "scw_zone" {
+  type        = string
+  description = "Scaleway zone for resources"
+}
+
+variable "managed" {
+  type        = string
+  description = "Indicates the resource is managed by Terraform"
+  default     = "Managed by Terraform"
+}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour permettre de stocker les uploads (logos et photos des traiteurs, pièces jointes des demandes, factures et devis PDF générés, etc.)
