### PR TITLE
Import de la clé d'API de staging de traiteurs-engages

### DIFF
--- a/infrastructure/traiteurs-engages/iam/terraform/README.md
+++ b/infrastructure/traiteurs-engages/iam/terraform/README.md
@@ -25,6 +25,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [scaleway_iam_api_key.api_key](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_api_key) | resource |
 | [scaleway_iam_application.app](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
 | [scaleway_iam_policy.policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_policy) | resource |
 | [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |

--- a/infrastructure/traiteurs-engages/iam/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/main.tf
@@ -13,6 +13,14 @@ resource "scaleway_iam_application" "app" {
   description = var.managed
 }
 
+resource "scaleway_iam_api_key" "api_key" {
+  application_id = scaleway_iam_application.app.id
+  description    = var.managed
+  # When authenticating Object Storage operations, SCW uses the default project
+  # linked to the API key.
+  default_project_id = data.scaleway_account_project.traiteurs_engages.project_id
+}
+
 resource "scaleway_iam_policy" "policy" {
   name           = "traiteurs-engages"
   description    = var.managed
@@ -26,4 +34,9 @@ resource "scaleway_iam_policy" "policy" {
       "ObjectStorageObjectsWrite",
     ]
   }
+}
+
+import {
+  to = scaleway_iam_api_key.api_key
+  id = "SCWY29BKPXVB49663RGX"
 }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour correctement documenter l'état (la clé a été créée manuellement pour ne pas l'avoir dans le state).