### PR TITLE
Ajout de la configuration de la production de traiteurs engages

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
@@ -26,6 +26,11 @@ module "dns-traiteurs-engages" {
       data = "proxy.applicatif.net."
       type = "ALIAS"
     },
+    "production" = {
+      name = "traiteurs-engages"
+      data = "traiteurs-engages-prod.osc-secnum-fr1.scalingo.io."
+      type = "CNAME"
+    },
 
     # Emails
     "staging-brevo-code" : {

--- a/infrastructure/traiteurs-engages/buckets/terraform/data.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/data.tf
@@ -7,6 +7,10 @@ data "scaleway_iam_application" "traiteurs_engages" {
   name = "traiteurs-engages"
 }
 
+data "scaleway_iam_application" "traiteurs_engages_production" {
+  name = "traiteurs-engages-production"
+}
+
 data "scaleway_iam_application" "terraform_ci" {
   name = "terraform-ci"
 }

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -86,3 +86,82 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
     },
   )
 }
+
+resource "scaleway_object_bucket" "uploads_bucket_production" {
+  provider = scaleway
+  name     = "traiteurs-engages-uploads-production"
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "uploads_bucket_production_acl" {
+  bucket = scaleway_object_bucket.uploads_bucket_production.id
+  acl    = "private"
+}
+
+resource "scaleway_object_bucket_policy" "uploads_bucket_production_policy" {
+  depends_on = [scaleway_object_bucket_acl.uploads_bucket_production_acl]
+  bucket     = scaleway_object_bucket.uploads_bucket_production.id
+  policy = jsonencode(
+    {
+      Version = "2023-04-17",
+      Statement = [
+        {
+          Sid    = "Allow Terraform CI to manage the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.terraform_ci.id}",
+            ],
+          },
+          Action = [
+            "s3:GetBucketAcl",
+            "s3:GetBucketCORS",
+            "s3:GetBucketLocation",
+            "s3:GetBucketObjectLockConfiguration",
+            "s3:GetBucketTagging",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketWebsite",
+            "s3:GetLifecycleConfiguration",
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:PutBucketAcl",
+            "s3:PutBucketCORS",
+            "s3:PutBucketObjectLockConfiguration",
+            "s3:PutBucketTagging",
+            "s3:PutBucketVersioning",
+            "s3:PutBucketWebsite",
+            "s3:PutLifecycleConfiguration",
+          ],
+          Resource = [
+            scaleway_object_bucket.uploads_bucket_production.name,
+          ],
+        },
+        {
+          Sid    = "Allow the traiteurs-engages production app to store and retrieve objects in the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages_production.id}",
+            ],
+          },
+          Action = [
+            # Bucket permissions
+            "s3:ListBucket",
+
+            # Object permissions
+            "s3:AbortMultipartUpload",
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket_production.name}",
+            "${scaleway_object_bucket.uploads_bucket_production.name}/*",
+          ],
+        },
+      ],
+    },
+  )
+}

--- a/infrastructure/traiteurs-engages/iam/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/main.tf
@@ -40,3 +40,31 @@ import {
   to = scaleway_iam_api_key.api_key
   id = "SCWY29BKPXVB49663RGX"
 }
+
+resource "scaleway_iam_application" "app_production" {
+  name        = "traiteurs-engages-production"
+  description = var.managed
+}
+
+resource "scaleway_iam_api_key" "api_key_production" {
+  application_id = scaleway_iam_application.app_production.id
+  description    = var.managed
+  # When authenticating Object Storage operations, SCW uses the default project
+  # linked to the API key.
+  default_project_id = data.scaleway_account_project.traiteurs_engages.project_id
+}
+
+resource "scaleway_iam_policy" "policy_production" {
+  name           = "traiteurs-engages-production"
+  description    = var.managed
+  application_id = scaleway_iam_application.app_production.id
+  rule {
+    project_ids = [data.scaleway_account_project.traiteurs_engages.project_id]
+    permission_set_names = [
+      "ObjectStorageBucketsRead",
+      "ObjectStorageObjectsDelete",
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+    ]
+  }
+}


### PR DESCRIPTION
## :thinking: Pourquoi ?      

  Préparer l'infrastructure de production pour Traiteurs engagés : le projet ne disposait   
  jusqu'ici que des ressources de staging (bucket S3, application IAM partagée). Cette PR
  ajoute les ressources de production équivalentes, en isolant les identifiants pour limiter
   le rayon d'impact en cas de fuite de la clé de staging.        

  ## :cake: Comment ?                                                                       
  
  Trois ajouts, dans le même projet Scaleway `traiteurs-engages` :                          
                                                                  
  - **IAM** : nouvelle application `traiteurs-engages-production` avec sa propre clé API et 
  sa propre policy (mêmes permissions Object Storage que l'app staging, scope limité au
  projet).                  
  - **S3** : nouveau bucket `traiteurs-engages-uploads-production` avec la même
  configuration que le bucket staging (versioning activé, ACL `private`, `force_destroy`    
  laissé à la valeur par défaut `false`).                      
  - **DNS** : nouveau CNAME `traiteurs-engages.inclusion.gouv.fr` →
  `traiteurs-engages-prod.osc-secnum-fr1.scalingo.io.` (région SecNumCloud Scalingo,        
  distincte de `osc-fr1` utilisée par le staging — choix intentionnel).
                                                                                                                                              
                                                                  
  L'enregistrement DNS existant `traiteurs.engages` (avec un point) →                       
  `proxy.applicatif.net.` n'a pas été touché ; à supprimer selon le futur de cette version.
                                                                                            
  ## :rotating_light: À vérifier                                  

  - [x] Le commit message est rédigé en anglais
  - [x] Le titre de la PR et sa présente description sont en français
