### PR TITLE
Correction du domaine web principal pour traiteurs-engages

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/traiteurs-engages/terraform/main.tf
@@ -22,6 +22,11 @@ module "dns-traiteurs-engages" {
       type = "ALIAS"
     },
     "prod" = {
+      name = "traiteurs-engages"
+      data = "traiteurs-engages-prod.osc-secnum-fr1.scalingo.io."
+      type = "ALIAS"
+    },
+    "prod-legacy" = {
       name = "traiteurs.engages"
       data = "proxy.applicatif.net."
       type = "ALIAS"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Créé par erreur en `traiteurs.engages` initialement.

## :cake: Comment ? <!-- optionnel -->

Conservation des deux domaines le temps de la transition.