### PR TITLE
Ajout de l'application IAM traiteurs-engages de production

### DIFF
--- a/infrastructure/traiteurs-engages/iam/terraform/README.md
+++ b/infrastructure/traiteurs-engages/iam/terraform/README.md
@@ -27,7 +27,9 @@ No modules.
 |------|------|
 | [scaleway_iam_api_key.api_key](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_api_key) | resource |
 | [scaleway_iam_application.app](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
+| [scaleway_iam_application.app_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
 | [scaleway_iam_policy.policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_policy) | resource |
+| [scaleway_iam_policy.policy_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_policy) | resource |
 | [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
 
 ## Inputs

--- a/infrastructure/traiteurs-engages/iam/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/main.tf
@@ -40,3 +40,23 @@ import {
   to = scaleway_iam_api_key.api_key
   id = "SCWY29BKPXVB49663RGX"
 }
+
+resource "scaleway_iam_application" "app_production" {
+  name        = "traiteurs-engages-production"
+  description = var.managed
+}
+
+resource "scaleway_iam_policy" "policy_production" {
+  name           = "traiteurs-engages-production"
+  description    = var.managed
+  application_id = scaleway_iam_application.app_production.id
+  rule {
+    project_ids = [data.scaleway_account_project.traiteurs_engages.project_id]
+    permission_set_names = [
+      "ObjectStorageBucketsRead",
+      "ObjectStorageObjectsDelete",
+      "ObjectStorageObjectsRead",
+      "ObjectStorageObjectsWrite",
+    ]
+  }
+}


### PR DESCRIPTION
…olicy

## :thinking: Pourquoi ?

Creation de l'IAM application pour gerer les buckets de prod traiteurs-engages


## :cake: Comment ? <!-- optionnel -->

Une application scope au projet, les buckets seront dans la PR d'apres avec une policy restreinte a cette application.


## :rotating_light: À vérifier

- [x] Le commit message est rédigé en anglais
- [x] Le titre de la PR et sa présente description sont en français
