### PR TITLE
Ajout des buckets de prod traiteurs engages

### DIFF
--- a/infrastructure/traiteurs-engages/buckets/terraform/README.md
+++ b/infrastructure/traiteurs-engages/buckets/terraform/README.md
@@ -27,11 +27,15 @@ No modules.
 | Name | Type |
 |------|------|
 | [scaleway_object_bucket.uploads_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
+| [scaleway_object_bucket.uploads_bucket_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
 | [scaleway_object_bucket_acl.uploads_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_acl.uploads_bucket_production_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
 | [scaleway_object_bucket_policy.uploads_bucket_policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_policy) | resource |
+| [scaleway_object_bucket_policy.uploads_bucket_production_policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_policy) | resource |
 | [scaleway_account_project.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
 | [scaleway_iam_application.terraform_ci](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
 | [scaleway_iam_application.traiteurs_engages](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
+| [scaleway_iam_application.traiteurs_engages_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/iam_application) | data source |
 
 ## Inputs
 

--- a/infrastructure/traiteurs-engages/buckets/terraform/data.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/data.tf
@@ -7,6 +7,10 @@ data "scaleway_iam_application" "traiteurs_engages" {
   name = "traiteurs-engages"
 }
 
+data "scaleway_iam_application" "traiteurs_engages_production" {
+  name = "traiteurs-engages-production"
+}
+
 data "scaleway_iam_application" "terraform_ci" {
   name = "terraform-ci"
 }

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -82,20 +82,6 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
             "${scaleway_object_bucket.uploads_bucket.name}/*",
           ],
         },
-        {
-          Sid    = "Deny the traiteurs-engages production app from accessing the staging bucket",
-          Effect = "Deny",
-          Principal = {
-            SCW = [
-              "application_id:${data.scaleway_iam_application.traiteurs_engages_production.id}",
-            ],
-          },
-          Action = "s3:*",
-          Resource = [
-            "${scaleway_object_bucket.uploads_bucket.name}",
-            "${scaleway_object_bucket.uploads_bucket.name}/*",
-          ],
-        },
       ],
     },
   )

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -161,20 +161,6 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_production_policy" {
             "${scaleway_object_bucket.uploads_bucket_production.name}/*",
           ],
         },
-        {
-          Sid    = "Deny the traiteurs-engages staging app from accessing the production bucket",
-          Effect = "Deny",
-          Principal = {
-            SCW = [
-              "application_id:${data.scaleway_iam_application.traiteurs_engages.id}",
-            ],
-          },
-          Action = "s3:*",
-          Resource = [
-            "${scaleway_object_bucket.uploads_bucket_production.name}",
-            "${scaleway_object_bucket.uploads_bucket_production.name}/*",
-          ],
-        },
       ],
     },
   )

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -82,6 +82,20 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
             "${scaleway_object_bucket.uploads_bucket.name}/*",
           ],
         },
+        {
+          Sid    = "Deny the traiteurs-engages production app from accessing the staging bucket",
+          Effect = "Deny",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages_production.id}",
+            ],
+          },
+          Action = "s3:*",
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket.name}",
+            "${scaleway_object_bucket.uploads_bucket.name}/*",
+          ],
+        },
       ],
     },
   )
@@ -156,6 +170,20 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_production_policy" {
             "s3:GetObject",
             "s3:PutObject",
           ],
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket_production.name}",
+            "${scaleway_object_bucket.uploads_bucket_production.name}/*",
+          ],
+        },
+        {
+          Sid    = "Deny the traiteurs-engages staging app from accessing the production bucket",
+          Effect = "Deny",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages.id}",
+            ],
+          },
+          Action = "s3:*",
           Resource = [
             "${scaleway_object_bucket.uploads_bucket_production.name}",
             "${scaleway_object_bucket.uploads_bucket_production.name}/*",

--- a/infrastructure/traiteurs-engages/buckets/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/buckets/terraform/main.tf
@@ -86,3 +86,82 @@ resource "scaleway_object_bucket_policy" "uploads_bucket_policy" {
     },
   )
 }
+
+resource "scaleway_object_bucket" "uploads_bucket_production" {
+  provider = scaleway
+  name     = "traiteurs-engages-uploads-production"
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "uploads_bucket_production_acl" {
+  bucket = scaleway_object_bucket.uploads_bucket_production.id
+  acl    = "private"
+}
+
+resource "scaleway_object_bucket_policy" "uploads_bucket_production_policy" {
+  depends_on = [scaleway_object_bucket_acl.uploads_bucket_production_acl]
+  bucket     = scaleway_object_bucket.uploads_bucket_production.id
+  policy = jsonencode(
+    {
+      Version = "2023-04-17",
+      Statement = [
+        {
+          Sid    = "Allow Terraform CI to manage the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.terraform_ci.id}",
+            ],
+          },
+          Action = [
+            "s3:GetBucketAcl",
+            "s3:GetBucketCORS",
+            "s3:GetBucketLocation",
+            "s3:GetBucketObjectLockConfiguration",
+            "s3:GetBucketTagging",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketWebsite",
+            "s3:GetLifecycleConfiguration",
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:PutBucketAcl",
+            "s3:PutBucketCORS",
+            "s3:PutBucketObjectLockConfiguration",
+            "s3:PutBucketTagging",
+            "s3:PutBucketVersioning",
+            "s3:PutBucketWebsite",
+            "s3:PutLifecycleConfiguration",
+          ],
+          Resource = [
+            scaleway_object_bucket.uploads_bucket_production.name,
+          ],
+        },
+        {
+          Sid    = "Allow the traiteurs-engages production app to store and retrieve objects in the bucket",
+          Effect = "Allow",
+          Principal = {
+            SCW = [
+              "application_id:${data.scaleway_iam_application.traiteurs_engages_production.id}",
+            ],
+          },
+          Action = [
+            # Bucket permissions
+            "s3:ListBucket",
+
+            # Object permissions
+            "s3:AbortMultipartUpload",
+            "s3:DeleteObject",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          Resource = [
+            "${scaleway_object_bucket.uploads_bucket_production.name}",
+            "${scaleway_object_bucket.uploads_bucket_production.name}/*",
+          ],
+        },
+      ],
+    },
+  )
+}


### PR DESCRIPTION
## :thinking: Pourquoi ?

le S3 pour la prod de traiteurs engages


## :cake: Comment ? <!-- optionnel -->

ISO avec un S3 classique, vu la double application dans le meme projet j'ai ajoute un DENY explicite dans les policies bucket


## :rotating_light: À vérifier

- [x] Le commit message est rédigé en anglais
- [x] Le titre de la PR et sa présente description sont en français
