### PR TITLE
Import de la clé d'API de production de traiteurs-engages

### DIFF
--- a/infrastructure/traiteurs-engages/iam/terraform/README.md
+++ b/infrastructure/traiteurs-engages/iam/terraform/README.md
@@ -26,6 +26,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [scaleway_iam_api_key.api_key](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_api_key) | resource |
+| [scaleway_iam_api_key.api_key_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_api_key) | resource |
 | [scaleway_iam_application.app](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
 | [scaleway_iam_application.app_production](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_application) | resource |
 | [scaleway_iam_policy.policy](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/iam_policy) | resource |

--- a/infrastructure/traiteurs-engages/iam/terraform/main.tf
+++ b/infrastructure/traiteurs-engages/iam/terraform/main.tf
@@ -46,6 +46,14 @@ resource "scaleway_iam_application" "app_production" {
   description = var.managed
 }
 
+resource "scaleway_iam_api_key" "api_key_production" {
+  application_id = scaleway_iam_application.app_production.id
+  description    = var.managed
+  # When authenticating Object Storage operations, SCW uses the default project
+  # linked to the API key.
+  default_project_id = data.scaleway_account_project.traiteurs_engages.project_id
+}
+
 resource "scaleway_iam_policy" "policy_production" {
   name           = "traiteurs-engages-production"
   description    = var.managed
@@ -59,4 +67,9 @@ resource "scaleway_iam_policy" "policy_production" {
       "ObjectStorageObjectsWrite",
     ]
   }
+}
+
+import {
+  to = scaleway_iam_api_key.api_key_production
+  id = "SCWNFG2PJ0513T18ZDFN"
 }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour correctement documenter l'état (la clé a été créée manuellement pour ne pas l'avoir dans le state).