### PR TITLE
ci: Retirer la permission id-token: write

### DIFF
--- a/.github/workflows/_terraform-module.yml
+++ b/.github/workflows/_terraform-module.yml
@@ -29,7 +29,6 @@ on:
 permissions:
   contents: read
   actions: read
-  id-token: write
 
 jobs:
   terraform:

--- a/.github/workflows/terraform-orchestrator.yml
+++ b/.github/workflows/terraform-orchestrator.yml
@@ -26,7 +26,6 @@ on:
 permissions:
   contents: read
   actions: read
-  id-token: write
 
 jobs:
   detect-modules:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Inutile, mieux vaut limiter les privilèges sur les actions.
