### PR TITLE
MAJ MX TTL a 5min

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/email/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/email/terraform/main.tf
@@ -44,35 +44,35 @@ module "dns-email" {
       data     = "alt1.aspmx.l.google.com."
       type     = "MX"
       priority = 5
-      ttl      = 1800
+      ttl      = 300
     },
     "google-mx-alt2" = {
       name     = ""
       data     = "alt2.aspmx.l.google.com."
       type     = "MX"
       priority = 5
-      ttl      = 1800
+      ttl      = 300
     },
     "google-mx-alt3" = {
       name     = ""
       data     = "alt3.aspmx.l.google.com."
       type     = "MX"
       priority = 10
-      ttl      = 1800
+      ttl      = 300
     },
     "google-mx-alt4" = {
       name     = ""
       data     = "alt4.aspmx.l.google.com."
       type     = "MX"
       priority = 10
-      ttl      = 1800
+      ttl      = 300
     },
     "google-mx-main" = {
       name     = ""
       data     = "aspmx.l.google.com."
       type     = "MX"
       priority = 1
-      ttl      = 1800
+      ttl      = 300
     },
     "imap" = {
       name = "imap"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Reduire le TTL a 5min pour que la propagation soit rapide au moment de la bascule de MX. Cette PR sera a merge pour apply le 10 debut d'apres-midi.

## :rotating_light: À vérifier

- [x] Le commit message est rédigé en anglais
- [x] Le titre de la PR et sa présente description sont en français
