### PR TITLE
Correction du push de l'autofix Dependabot (terraform-docs)

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the PR branch instead of the detached merge commit, so the docs commit can be pushed
+          ref: ${{ github.head_ref }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le workflow dependabot-autofix échouait à l'étape "Generate Terraform docs" (`fatal: You are not currently on a branch.`).

Sur un événement `pull_request`, l'action `checkout` récupère par défaut le commit de merge, donc un HEAD détaché. L'action `terraform-docs` créait bien son commit mais le git push échouait faute de branche courante.

Refs: https://github.com/gip-inclusion/infrastructure/actions/runs/26920151873/job/79418725629

## :cake: Comment ? <!-- optionnel -->

Checkout explicite de la branche de la PR.