### PR TITLE
emails: Mettre à jour la version de MTA-STS

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/email/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/email/terraform/main.tf
@@ -51,7 +51,7 @@ module "dns-email" {
     },
     "mta-sts-txt" = {
       name = "_mta-sts"
-      data = "v=STSv1; id=20260608T120200"
+      data = "v=STSv1; id=20260611T120200"
       type = "TXT"
       ttl  = 10800
     },


### PR DESCRIPTION
## :thinking: Pourquoi ?

La nouvelle version retirant les serveurs de Google a été déployée.
