### PR TITLE
dns: Ajouter un enregistrement pour l'encart Accueil

### DIFF
--- a/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
+++ b/infrastructure/iac-gip-inclusion/dns/gip-inclusion/terraform/main.tf
@@ -16,6 +16,12 @@ module "dns-gip-inclusion" {
   scw_project_id = data.scaleway_account_project.iac_gip_inclusion.project_id
 
   records = {
+    "accueil-plateforme" = {
+      name = "accueil.plateforme"
+      data = "novarw2u9ckv-plateforme-accueil.functions.fnc.fr-par.scw.cloud."
+      type = "CNAME"
+      ttl  = 10800
+    },
     "attio-domain-verification" = {
       name = ""
       data = "attio-domain-verification=E0JJRAACK295CWRVJG71W300"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cf. https://github.com/gip-inclusion/les-emplois/pull/8431 – le contenu de l'accueil est sur une iframe qui a un adresse Scaleway disgracieuse. Cette PR lui donne une URL correcte et permet de mieux gérer les autorisations de l'iframe (pisque origine semblable).

## :cake: Comment ? <!-- optionnel -->

Sous-domaine **`accueil.plateforme.inclusion.gouv.fr`**.

## :rotating_light: À vérifier

- [x] Le commit message est rédigé en anglais
- [x] Le titre de la PR et sa présente description sont en français
